### PR TITLE
This pull has both the enabled check box and a hack to allow test suite field to use params

### DIFF
--- a/src/main/java/hudson/plugins/seleniumhq/SeleniumhqBuilder.java
+++ b/src/main/java/hudson/plugins/seleniumhq/SeleniumhqBuilder.java
@@ -246,6 +246,12 @@ public class SeleniumhqBuilder extends Builder {
                  return false;         	 
         	 }
          }
+         //see if we've got a jenkins variable. if so just pass it along
+         else if (this.suiteFile.startsWith("$"))
+         {
+             listener.getLogger().println("Suite File Looks Like a Parameter: "+ this.suiteFile);
+             suiteFile = this.suiteFile;
+         }
          else
          {
                 // The suiteFile it is a unsuported type

--- a/src/main/resources/hudson/plugins/seleniumhq/SeleniumhqBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/seleniumhq/SeleniumhqBuilder/config.jelly
@@ -4,6 +4,9 @@
 
     See global.jelly for a general discussion about jelly script.
     -->
+    <f:entry title="Enabled" help="${rootURL}/plugin/seleniumhq/help-builder-testEnabled.html">
+        <f:checkbox field="testEnabled" checked="${instance.testEnabled}" default="true" />
+    </f:entry>
     <f:entry title="browser" help="${rootURL}/plugin/seleniumhq/help-builder-browser.html">
         <f:textbox field="browser" clazz="required" checkMessage="${%mandatory.browser}"/>
     </f:entry>


### PR DESCRIPTION
Right now you need to create a file named the param variable into the workspace to pass the test suite checks. This allows us to use 1 param (a limitation in this version) in place of a file path.
